### PR TITLE
Fix typo + add link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Installation
   * Clone the repo `git clone https://github.com/SquitchYT/Comfy-Chrome`
-  * Goto `chrome://extenstions/` and enable developer mode
+  * Goto [`chrome://extensions/`](chrome://extensions/) and enable developer mode
   * Click `load unpacked` and select the theme folder
   * Enjoy
 


### PR DESCRIPTION
The chrome://extensions/ had a typo in it.
I also made it a link.

It's not much but any improvement is good I guess